### PR TITLE
Fix not working in non-file tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,11 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onCommand:extension.togglePinEditor"
-  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "toggle-pin-editor.helloWorld",
+        "command": "togglePinEditor.togglePinEditor",
         "title": "Toggle Pin Editor"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,22 +1,13 @@
 import * as vscode from "vscode";
-const pinnedTabs: Map<string, boolean> = new Map();
 
 export const disposable = vscode.commands.registerCommand(
-  "extension.togglePinEditor",
+  "togglePinEditor.togglePinEditor",
   () => {
-    const editor = vscode.window.activeTextEditor;
-    const filePath = editor?.document.uri.toString();
-    const isPinned = pinnedTabs.get(filePath ?? "") ?? false;
+    const isPinned = vscode.window.tabGroups.activeTabGroup.activeTab?.isPinned;
     if (isPinned) {
       vscode.commands.executeCommand("workbench.action.unpinEditor");
-      if (filePath) {
-        pinnedTabs.delete(filePath);
-      }
     } else {
       vscode.commands.executeCommand("workbench.action.pinEditor");
-      if (filePath) {
-        pinnedTabs.set(filePath, true);
-      }
     }
   }
 );


### PR DESCRIPTION
Currently, the extension is not able to unpin tabs that do not have a file path (e.g. settings tabs, git history tabs, keybind editor tab, etc). This PR fixes this. Tested on my machine.